### PR TITLE
Update app_console.lua

### DIFF
--- a/parts/scenes/app_console.lua
+++ b/parts/scenes/app_console.lua
@@ -590,7 +590,7 @@ local commands={}do
             {
                 code="link",
                 scene='app_link',
-                description="Simple link game"
+                description="Connect tiles, a.k.a. Shisen-Sho"
             },
         }
         commands.app={


### PR DESCRIPTION
update description of Link. Shisen-Sho (四川省) is the Japanese name of this game, for there is no other names accepted in the English language. No, I'm not accepting "Link link go" as an acceptable name. No, Mahjong Solitaire is a totally different game.