### PR TITLE
[no ci] Change icon, temporary fix for dylib loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         python .\.github\workflows\updateVersion.py -T Windows -N ${{ env.Version }}
         cmd /c '.\ResourceHacker.exe -open .\love-11.3-win64\Techmino.exe -save .\love-11.3-win64\Techmino.exe -action delete -mask ICONGROUP,,'
         cmd /c '.\ResourceHacker.exe -open .\Techmino.rc -save .\Techmino.res -action compile'
-        cmd /c '.\ResourceHacker.exe -open .\love-11.3-win64\Techmino.exe -save .\love-11.3-win64\Techmino.exe -action addoverwrite -res ".\build\Windows\icon_snapshot.ico" -mask ICONGROUP,1,'
+        cmd /c '.\ResourceHacker.exe -open .\love-11.3-win64\Techmino.exe -save .\love-11.3-win64\Techmino.exe -action addoverwrite -res ".\.github\build\Windows\icon_snapshot.ico" -mask ICONGROUP,1,'
         cmd /c '.\ResourceHacker.exe -open .\love-11.3-win64\Techmino.exe -save .\love-11.3-win64\Techmino.exe -action addoverwrite -res ".\Techmino.res" -mask VERSIONINFO,1,'
     - name: Upload
       uses: actions/upload-artifact@v2
@@ -118,9 +118,9 @@ jobs:
     - name: Pack Techmino
       run: |
         rm -rf ./squashfs-root/love ./squashfs-root/love.desktop ./squashfs-root/love.svg ./squashfs-root/.DirIcon
-        mv ./build/Linux/love.template ./squashfs-root/love
-        mv ./build/Linux/Techmino.desktop.template ./squashfs-root/Techmino.desktop
-        mv ./build/Linux/icon_snapshot.png ./squashfs-root/icon.png
+        mv ./.github/build/Linux/love.template ./squashfs-root/love
+        mv ./.github/build/Linux/Techmino.desktop.template ./squashfs-root/Techmino.desktop
+        mv ./.github/build/Linux/icon_snapshot.png ./squashfs-root/icon.png
         cp ./squashfs-root/icon.png ./squashfs-root/.DirIcon
         chmod 777 ./squashfs-root/love
         mkdir -p ./squashfs-root/usr/share/Techmino

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,6 +256,7 @@ jobs:
         python3 ./.github/workflows/updateVersion.py -T macOS -N $(lua ./.github/workflows/getVersion.lua -name)
         mv ./Techmino.love ./Techmino.app/Contents/Resources
         mv ./CCloader.dylib ./Techmino.app/Contents/Frameworks
+        mv ./.github/build/macOS/icon.icns ./Techmino.app/Contents/Resources/iconfile.icns
     - name: Codesign executable
       # In secrets:
       #   - MACOS_CERTIFICATE: the *.p12 Developer ID Certificate, encoded in base64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,7 @@ jobs:
         python3 ./.github/workflows/updateVersion.py -T macOS -N $(lua ./.github/workflows/getVersion.lua -name)
         mv ./Techmino.love ./Techmino.app/Contents/Resources
         mv ./CCloader.dylib ./Techmino.app/Contents/Frameworks
-        mv ./.github/build/macOS/icon.icns ./Techmino.app/Contents/Resources/iconfile.icns
+        mv ./.github/build/macOS/icon_snapshot.icns ./Techmino.app/Contents/Resources/iconfile.icns
     - name: Codesign executable
       # In secrets:
       #   - MACOS_CERTIFICATE: the *.p12 Developer ID Certificate, encoded in base64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,6 +380,7 @@ jobs:
         python3 ./.github/workflows/updateVersion.py -T macOS -N $(lua ./.github/workflows/getVersion.lua -name)
         mv ./Techmino.love ./Techmino.app/Contents/Resources
         mv ./CCloader.dylib ./Techmino.app/Contents/Frameworks
+        mv ./.github/build/macOS/icon.icns ./Techmino.app/Contents/Resources/iconfile.icns
     - name: Codesign executable
       # In secrets:
       #   - MACOS_CERTIFICATE: the *.p12 Developer ID Certificate, encoded in base64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,9 +178,9 @@ jobs:
     - name: Pack Techmino
       run: |
         rm -rf ./squashfs-root/love ./squashfs-root/love.desktop ./squashfs-root/love.svg ./squashfs-root/.DirIcon
-        mv ./build/Linux/love.template ./squashfs-root/love
-        mv ./build/Linux/Techmino.desktop.template ./squashfs-root/Techmino.desktop
-        mv ./build/Linux/icon.png ./squashfs-root/icon.png
+        mv ./.github/build/Linux/love.template ./squashfs-root/love
+        mv ./.github/build/Linux/Techmino.desktop.template ./squashfs-root/Techmino.desktop
+        mv ./.github/build/Linux/icon.png ./squashfs-root/icon.png
         cp ./squashfs-root/icon.png ./squashfs-root/.DirIcon
         chmod 777 ./squashfs-root/love
         mkdir -p ./squashfs-root/usr/share/Techmino

--- a/.github/workflows/updateVersion.py
+++ b/.github/workflows/updateVersion.py
@@ -24,7 +24,7 @@ def updateVersion(args):    #更新版本号
 def updateMacOS(args):  #更新macOS打包信息
     import datetime
     thisYear = str(datetime.datetime.today().year)
-    with open('./build/macOS/info.plist.template', 'r', encoding='utf-8') as file:
+    with open('./.github/build/macOS/info.plist.template', 'r', encoding='utf-8') as file:
         data = file.read()
         data = data\
             .replace('@versionName', args.Name)\
@@ -35,7 +35,7 @@ def updateMacOS(args):  #更新macOS打包信息
 def updateWindows(args):    #更新Windows打包信息
     Version = (args.Name).replace('V', '')
     FileVersion = (f"{Version.replace('.', ',')},0")
-    with open('./build/Windows/Techmino.rc.template', 'r', encoding='utf8') as file:
+    with open('./.github/build/Windows/Techmino.rc.template', 'r', encoding='utf8') as file:
         data = file.read()
         data = data\
             .replace('@FileVersion', FileVersion)\

--- a/Zframework/require.lua
+++ b/Zframework/require.lua
@@ -26,7 +26,7 @@ return function(libName)
 			MES.new('check',name.." lib loaded")
 			return a
 		else
-			MES.new('error',"Cannot load "..name.." in Mac OS X.")
+			MES.new('error',"Cannot load "..libName.." in Mac OS X.")
 		end
     end
     local r1,r2,r3=pcall(require,libName)

--- a/Zframework/require.lua
+++ b/Zframework/require.lua
@@ -20,7 +20,7 @@ return function(libName)
             loaded[libName]=true
         end
     elseif SYSTEM=="OS X" then
-		local rtn = package.loadlib(libName, libName.libFunc)
+		local rtn = package.loadlib(libName, 'luaopen_'..libName)
 		if rtn then
 			local a = rtn()
 			MES.new('check',name.." lib loaded")

--- a/Zframework/require.lua
+++ b/Zframework/require.lua
@@ -23,7 +23,6 @@ return function(libName)
 		local rtn = package.loadlib(libName..'.dylib', 'luaopen_'..libName)
 		if rtn then
 			local a = rtn()
-			MES.new('check',name.." lib loaded")
 			return a
 		else
 			MES.new('error',"Cannot load "..libName.." in Mac OS X.")

--- a/Zframework/require.lua
+++ b/Zframework/require.lua
@@ -1,7 +1,11 @@
 package.cpath=package.cpath..';'..SAVEDIR..'/lib/lib?.so;'..'?.dylib'
 local loaded={}
 return function(libName)
-    if SYSTEM=='Android'then
+    local require=require
+    if SYSTEM=='OS X'then
+        require=package.loadlib(libName..'.dylib','luaopen_'..libName)
+        libname=nil
+    elseif SYSTEM=='Android'then
         if not loaded[libName]then
             local platform=(function()
                 local p=io.popen('uname -m')
@@ -19,20 +23,11 @@ return function(libName)
             )
             loaded[libName]=true
         end
-    elseif SYSTEM=="OS X" then
-		local rtn = package.loadlib(libName..'.dylib', 'luaopen_'..libName)
-		if rtn then
-			local a = rtn()
-			return a
-		else
-			MES.new('error',"Cannot load "..libName.." in Mac OS X.")
-			return
-		end
     end
-    local r1,r2,r3=pcall(require,libName)
-    if r1 and r2 then
-        return r2
+    local success,res=pcall(require,libName)
+    if success and res then
+        return res
     else
-        MES.new('error',"Cannot load "..libName..": "..(r2 or r3))
+        MES.new('error',"Cannot load "..libName..": "..res)
     end
 end

--- a/Zframework/require.lua
+++ b/Zframework/require.lua
@@ -19,6 +19,15 @@ return function(libName)
             )
             loaded[libName]=true
         end
+    elseif SYSTEM=="OS X" then
+		local rtn = package.loadlib(libName, libName.libFunc)
+		if rtn then
+			local a = rtn()
+			MES.new('check',name.." lib loaded")
+			return a
+		else
+			MES.new('error',"Cannot load "..name.." in Mac OS X.")
+		end
     end
     local r1,r2,r3=pcall(require,libName)
     if r1 and r2 then

--- a/Zframework/require.lua
+++ b/Zframework/require.lua
@@ -20,13 +20,14 @@ return function(libName)
             loaded[libName]=true
         end
     elseif SYSTEM=="OS X" then
-		local rtn = package.loadlib(libName, 'luaopen_'..libName)
+		local rtn = package.loadlib(libName..'.dylib', 'luaopen_'..libName)
 		if rtn then
 			local a = rtn()
 			MES.new('check',name.." lib loaded")
 			return a
 		else
 			MES.new('error',"Cannot load "..libName.." in Mac OS X.")
+			return
 		end
     end
     local r1,r2,r3=pcall(require,libName)


### PR DESCRIPTION
closes #319 but you still need a round-cornered icon for snapshots. (**EDIT**: #325 added the snapshot icon.)

I can't figure out how to use `require` to directly load from MacOS frameworks. I think we have to settle on `package.loadlib`. This has to do with löve, and you might want to file an issue there.

Remember to squash!