### PR TITLE
Allow Zframework to be checked out

### DIFF
--- a/.github/actions/automatic-test/action.yml
+++ b/.github/actions/automatic-test/action.yml
@@ -5,6 +5,8 @@ runs:
   using: "composite"
   steps:
   - uses: actions/checkout@v2
+    with:
+      submodules: 'true'
   - uses: ./.github/actions/build-love
     with:
       file-path: Techmino.love

--- a/.github/actions/automatic-test/action.yml
+++ b/.github/actions/automatic-test/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
   - uses: actions/checkout@v2
     with:
-      submodules: 'true'
+      submodules: 'recursive'
   - uses: ./.github/actions/build-love
     with:
       file-path: Techmino.love

--- a/.github/actions/automatic-test/action.yml
+++ b/.github/actions/automatic-test/action.yml
@@ -4,9 +4,6 @@ description: 'Check for obvious errors.'
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v2
-    with:
-      submodules: 'recursive'
   - uses: ./.github/actions/build-love
     with:
       file-path: Techmino.love

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,8 +16,6 @@ jobs:
       commit: ${{ steps.actual-get-info.outputs.commit }}
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: 'recursive'
     - name: Install lua
       run: |
         sudo apt-get install lua5.3 -y

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/automatic-test
 
   build-windows:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,6 +16,8 @@ jobs:
       commit: ${{ steps.actual-get-info.outputs.commit }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - name: Install lua
       run: |
         sudo apt-get install lua5.3 -y
@@ -31,6 +33,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
     - uses: ./.github/actions/automatic-test
 
   build-windows:
@@ -38,6 +42,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -60,6 +66,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -78,6 +86,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -103,6 +113,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -131,6 +143,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -159,6 +173,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -192,6 +208,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
     - uses: ./.github/actions/build-love
       with:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - name: Install lua
       run: |
         sudo apt-get install lua5.3 -y
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/automatic-test
 
   build-windows:
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -67,7 +67,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -87,7 +87,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -114,7 +114,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -144,7 +144,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -174,7 +174,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -209,7 +209,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
     - uses: ./.github/actions/build-love
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
     needs: get-info
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-windows
         with:
@@ -62,6 +64,8 @@ jobs:
     needs: get-info
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-windows
         with:
@@ -83,6 +87,8 @@ jobs:
     needs: get-info
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-linux
         with:
@@ -99,6 +105,8 @@ jobs:
     needs: get-info
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-android
         with:
@@ -121,6 +129,8 @@ jobs:
     needs: get-info
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-macos
         with:
@@ -148,6 +158,8 @@ jobs:
     needs: get-info
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-ios
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-windows
         with:
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-windows
         with:
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-linux
         with:
@@ -106,7 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-android
         with:
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-macos
         with:
@@ -159,7 +159,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          submodules: 'recursive'
       - uses: ./.github/actions/update-version
       - uses: ./.github/actions/build-ios
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -58,7 +58,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -78,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -105,7 +105,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -134,7 +134,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: 'true'
+        submodules: 'recursive'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -55,6 +57,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -73,6 +77,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -98,6 +104,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}
@@ -125,6 +133,8 @@ jobs:
     needs: get-info
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
     - uses: ./.github/actions/update-version
       with:
         commit: ${{ needs.get-info.outputs.commit }}


### PR DESCRIPTION
Keep in mind that in the unlikely scenario of *nested* submodules (e.g. Zframework spun off yet another submodule), these needs to be modified to `"recursive"`. But to prevent unexpected checkouts, it should not be like that now.