### PR TITLE
VIetnamese translation update

### DIFF
--- a/parts/language/lang_en.lua
+++ b/parts/language/lang_en.lua
@@ -336,7 +336,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy and cộng đồng TVN",
+        "Shard Nguyễn, Squishy, TVN community",
         "",
         "Performances",
         "Electric283",

--- a/parts/language/lang_en.lua
+++ b/parts/language/lang_en.lua
@@ -336,7 +336,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy and cộng đồng TVN",
         "",
         "Performances",
         "Electric283",

--- a/parts/language/lang_es.lua
+++ b/parts/language/lang_es.lua
@@ -336,7 +336,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy and TVN community",
         "",
         "Performances",
         "Electric283",

--- a/parts/language/lang_es.lua
+++ b/parts/language/lang_es.lua
@@ -336,7 +336,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy and TVN community",
+        "Shard Nguyễn, Squishy, TVN community",
         "",
         "Performances",
         "Electric283",

--- a/parts/language/lang_fr.lua
+++ b/parts/language/lang_fr.lua
@@ -304,7 +304,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy, TVN community",
         "",
         "Performance",
         "Electric283",

--- a/parts/language/lang_id.lua
+++ b/parts/language/lang_id.lua
@@ -337,7 +337,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy, TVN community",
         "",
         "Pertunjukan",
         "Electric283",

--- a/parts/language/lang_ja.lua
+++ b/parts/language/lang_ja.lua
@@ -338,7 +338,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy, TVN community",
         "",
         "パフォーマンス",
         "Electric283",

--- a/parts/language/lang_pt.lua
+++ b/parts/language/lang_pt.lua
@@ -325,7 +325,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy, TVN community",
         "",
         "Performance",
         "Electric283",

--- a/parts/language/lang_vi.lua
+++ b/parts/language/lang_vi.lua
@@ -485,14 +485,14 @@ return {
             ctrl="Cài đặt điều khiển",
             key="Cài đặt bố cục phím",
             touch="Cài đặt cảm ứng",
-            showVK="Hiển thị nút ảo",
+            showVK="Điều khiển cảm ứng", -- Pull from Galaxy
             reTime="Đếm ngược bắt đầu",
             RS="Hệ thống xoay gạch",
             menuPos="Vị trí nút Menu",
             sysCursor="Sử dụng con trỏ chuột của hệ thống",
             autoPause="Tạm dừng khi nhấn ngoài game",
             autoSave="Tự động lưu các thành tích",
-            simpMode="Chế độ đơn giản",
+            simpMode="Chế độ Đơn giản",
         },
         setting_video={
             title="Cài đặt đồ hoạ",
@@ -536,7 +536,7 @@ return {
             msaa="MSAA level",
 
             bg_on="Ảnh nền thường",
-            bg_off="Ảnh nền trống",
+            bg_off="Không ảnh nền",
             bg_custom="Dùng ảnh nền tự chọn",
 
             blockSatur="Độ đậm gạch",
@@ -577,8 +577,8 @@ return {
             reset="Đặt lại",
         },
         setting_key={
-            a1="Di chuyển Trái",
-            a2="Di chuyển Phải",
+            a1="Sang Trái",
+            a2="Sang Phải",
             a3="Xoay Phải",
             a4="Xoay Trái",
             a5="Xoay 180°",
@@ -612,7 +612,7 @@ return {
             shape="Hình dạng",
         },
         setting_touchSwitch={
-            b1= "Di chuyển Trái:",    b2="Di chuyển Phải:",  b3="Xoay Phải:",  b4="Xoay Trái:",
+            b1= "Sang Trái:",    b2="Sang Phải:",  b3="Xoay Phải:",  b4="Xoay Trái:",
             b5= "Xoay 180°:",  b6="Thả Mạnh:",   b7="Thả Nhẹ:",     b8="Giữ:",
             b9= "Chức năng 1:",   b10="Chức năng 2:", b11="Trái tức thì:", b12="Phải tức thì:",
             b13="Sonic Drop:",   b14="Xuống 1:",     b15="Xuống 4:",       b16="Xuống 10:",
@@ -806,7 +806,7 @@ return {
             setting="Cài đặt",
             vk="Bố cục phím ảo",
 
-            couldSave="Lưu qua Cloud (LƯU Ý: ĐANG THỬ NGHIỆM)",
+            couldSave="Lưu qua Cloud (CẢNH BÁO: ĐANG THỬ NGHIỆM)",
             notLogin="[Đăng nhập để lưu]",
             upload="Tải lên Cloud",
             download="Tải xuống từ Cloud",
@@ -925,7 +925,7 @@ return {
     },
     getTip={refuseCopy=true,
         ":dcgpray:",
-        "Không thể mở file “Techmino.app” vì người làm game đã bay màu",
+        "Không thể mở “Techmino.app” vì người làm game đã bay màu",
         "“Techmino.app” là vi rút đấy. Xoá đi",
         "“TechminOS”",
         "(RUR’U’)R’FR2U’R’U’(RUR’F’)",

--- a/parts/language/lang_vi.lua
+++ b/parts/language/lang_vi.lua
@@ -1,5 +1,6 @@
 local C=COLOR
 return {
+    fallback='en',
     loadText={
         loadSFX="Đang tải các hiệu ứng âm thanh",
         loadSample="Đang tải các mẫu nhạc cụ",
@@ -336,7 +337,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy, cộng đồng TVN",
         "",
         "Performances",
         "Electric283",

--- a/parts/language/lang_vi.lua
+++ b/parts/language/lang_vi.lua
@@ -585,8 +585,8 @@ return {
             a6="Thả Mạnh",
             a7="Thả Nhẹ",
             a8="Giữ (Hold)",
-            a9="Chức năng 1",
-            a10="Chức năng 2",
+            a9="Chức năng 1 (F1)",
+            a10="Chức năng 2 (F2)",
             a11="Trái tức thì",
             a12="Phải tức thì",
             a13="Thả Nhanh",
@@ -614,8 +614,8 @@ return {
         setting_touchSwitch={
             b1= "Sang Trái:",    b2="Sang Phải:",  b3="Xoay Phải:",  b4="Xoay Trái:",
             b5= "Xoay 180°:",  b6="Thả Mạnh:",   b7="Thả Nhẹ:",     b8="Giữ:",
-            b9= "Chức năng 1:",   b10="Chức năng 2:", b11="Trái tức thì:", b12="Phải tức thì:",
-            b13="Sonic Drop:",   b14="Xuống 1:",     b15="Xuống 4:",       b16="Xuống 10:",
+            b9= "Chức năng 1 (F1):",   b10="Chức năng 2 (F2):", b11="Trái tức thì:", b12="Phải tức thì:",
+            b13="Thả nhanh:",   b14="Xuống 1:",     b15="Xuống 4:",       b16="Xuống 10:",
             b17="Thả Trái:",    b18="Thả Phải:", b19="Zangi Trái:",   b20="Zangi Phải:",
 
             norm="Thường",

--- a/parts/language/lang_vi.lua
+++ b/parts/language/lang_vi.lua
@@ -485,7 +485,7 @@ return {
             ctrl="Cài đặt điều khiển",
             key="Cài đặt bố cục phím",
             touch="Cài đặt cảm ứng",
-            showVK="Điều khiển cảm ứng", -- Pull from Galaxy
+            showVK="Bật điều khiển bằng cảm ứng", -- Pull from Galaxy
             reTime="Đếm ngược bắt đầu",
             RS="Hệ thống xoay gạch",
             menuPos="Vị trí nút Menu",

--- a/parts/language/lang_vi.lua
+++ b/parts/language/lang_vi.lua
@@ -538,7 +538,7 @@ return {
 
             bg_on="Ảnh nền thường",
             bg_off="Không ảnh nền",
-            bg_custom="Dùng ảnh nền tự chọn",
+            bg_custom="Ảnh nền tự chọn",
 
             blockSatur="Độ đậm gạch",
             fieldSatur="Độ đậm bảng",

--- a/parts/language/lang_zh.lua
+++ b/parts/language/lang_zh.lua
@@ -337,7 +337,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy, TVN community",
         "",
         "演出",
         "Electric283",

--- a/parts/language/lang_zh_code.lua
+++ b/parts/language/lang_zh_code.lua
@@ -285,7 +285,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy and TVN community",
         "",
         "演出",
         "Electric283",

--- a/parts/language/lang_zh_trad.lua
+++ b/parts/language/lang_zh_trad.lua
@@ -337,7 +337,7 @@ return {
         "NOT_A_ROBOT",
         "XMiao",
         "sakurw, Airun, 幽灵3383",
-        "Shard Nguyễn, Squishy và cộng đồng TVN",
+        "Shard Nguyễn, Squishy, TVN community",
         "",
         "Performances",
         "Electric283",


### PR DESCRIPTION
I have changed some strings into more suitable one
Also fix a error that it stuck in my head: there is a mistake in credit made by Shard, fixed now
It should be ``Shard Nguyễn, Squishy, (and) TVN community``, but Shard wrote ``Shard Nguyễn, Squishy và TVN community`` (he thought he just wrote the credit in Vietnamese but he (and I) didn't know/notice that it should be in English)

Very sorry for this mistake
You can merge this PR now without waiting