### PR TITLE
Giant pieces

### DIFF
--- a/Zframework/file.lua
+++ b/Zframework/file.lua
@@ -46,7 +46,7 @@ function FILE.load(name,args)
             error('unknown mode')
         end
     elseif not STRING.sArg(args,'-canskip') then
-        error('no file')
+        --error('no file')
     end
 end
 function FILE.save(data,name,args)

--- a/main.lua
+++ b/main.lua
@@ -16,6 +16,11 @@
 -- Var leak check
 -- setmetatable(_G,{__newindex=function(self,k,v) print('>>'..k..string.rep(" ",26-#k),debug.traceback():match("\n.-\n\t(.-): "))rawset(self,k,v) end})
 
+-- Local Lua Debugger VS Code Debug
+if os.getenv("LOCAL_LUA_DEBUGGER_VSCODE") == "1" then
+    require("lldebugger").start()
+end
+
 -- System Global Vars Declaration
 local fs=love.filesystem
 VERSION=require"version"

--- a/parts/RSlist.lua
+++ b/parts/RSlist.lua
@@ -834,6 +834,9 @@ do
         kickTable=TABLE.new(set3,29),
     }
     ARS_Z.kickTable[7],ARS_Z.kickTable[25]=set4,set4-- I,I5
+    for i = 30, 58 do
+        ARS_Z.kickTable[i]=_big(ARS_Z.kickTable[i-29])
+    end
 end
 
 local DRS_weak
@@ -900,6 +903,9 @@ do
             Z,Z,-- I2,O1
         }
     }
+    for i = 30, 58 do
+        DRS_weak.kickTable[i]=_big(DRS_weak.kickTable[i-29])
+    end
 end
 
 local ASC
@@ -943,6 +949,9 @@ do
             [02]=F,[20]=F,[13]=F,[31]=F,
         },29)
     }
+    for i = 30, 58 do
+        ASC.kickTable[i]=_big(ASC.kickTable[i-29])
+    end
 end
 
 local ASC_plus
@@ -972,6 +981,9 @@ do
             [02]=F,[20]=F,[13]=F,[31]=F,
         },29)
     }
+    for i = 30, 58 do
+        ASC_plus.kickTable[i]=_big(ASC_plus.kickTable[i-29])
+    end
 end
 
 local C2
@@ -988,6 +1000,9 @@ do
             [02]=L,[20]=L,[13]=L,[31]=L,
         },29)
     }
+    for i = 30, 58 do
+        C2.kickTable[i]=_big(C2.kickTable[i-29])
+    end
 end
 
 local C2_sym
@@ -1029,6 +1044,9 @@ do
             Z,Z,-- I2,O1
         }
     }
+    for i = 30, 58 do
+        C2_sym.kickTable[i]=_big(C2_sym.kickTable[i-29])
+    end
 end
 
 local N64
@@ -1045,6 +1063,9 @@ do
             [23]=R,[32]=L,[30]=R,[03]=L,
         },29)
     }
+    for i = 30, 58 do
+        N64.kickTable[i]=_big(N64.kickTable[i-29])
+    end
 end
 
 local N64_plus
@@ -1063,6 +1084,9 @@ do
             [02]=F,[20]=F,[13]=F,[31]=F,
         },29)
     }
+    for i = 30, 58 do
+        N64_plus.kickTable[i]=_big(N64_plus.kickTable[i-29])
+    end
 end
 
 local Classic do
@@ -1083,7 +1107,7 @@ local Classic do
             {'line',7,8,2,8,2,2,7,2},
         },
         centerPos=centerPos,
-        kickTable=TABLE.new(noKickSet,29)
+        kickTable=TABLE.new(noKickSet,58)
     }
 end
 
@@ -1104,7 +1128,7 @@ local Classic_plus do
             {'fRect',3,3,4,4},
         },
         centerPos=centerPos,
-        kickTable=TABLE.new(noKickSet_180,29)
+        kickTable=TABLE.new(noKickSet_180,58)
     }
 end
 
@@ -1113,7 +1137,7 @@ local None={
             {'setLW',2},
             {'line',2,2,6,6},
         },
-    kickTable=TABLE.new(noKickSet,29)
+    kickTable=TABLE.new(noKickSet,58)
 }
 
 local None_plus={
@@ -1122,7 +1146,7 @@ local None_plus={
             {'line',1,1,7,7},
             {'fRect',2,2,4,4},
         },
-    kickTable=TABLE.new(noKickSet_180,29)
+    kickTable=TABLE.new(noKickSet_180,58)
 }
 
 local RSlist={

--- a/parts/RSlist.lua
+++ b/parts/RSlist.lua
@@ -40,6 +40,21 @@ local defaultCenterPos={-- For SRS-like RSs
     {[0]={0,0},{0,0},{0,0},{0,0}},-- O1
 }
 
+local function _bigRotationCenter(centerList)
+    local bigCenterList = {}
+    for i, list in next, centerList do
+        -- Deduce the distance from bottom-left of the piece. Bottom-left is at (-0.5,-0.5)
+        local distX = list[1]+0.5
+        local distY = list[2]+0.5
+        bigCenterList[i]={distX * 2 - 0.5, distY * 2 - 0.5}
+    end
+    return bigCenterList
+end
+
+for i = 30,58 do
+    defaultCenterPos[i]=_bigRotationCenter(defaultCenterPos[i-29])
+end
+
 local noKickSet,noKickSet_180 do
     local Zero={{0,0}}
     noKickSet={[01]=Zero,[10]=Zero,[03]=Zero,[30]=Zero,[12]=Zero,[21]=Zero,[32]=Zero,[23]=Zero}
@@ -71,6 +86,18 @@ local function _flipList(O)
     return L
 end
 
+-- Use this to create a giant piece kick set out of the existing kick table
+local function _bigList(O)
+    if not O or type(O[1])~='string' then
+        return
+    end
+    local L={}
+    for i,s in next,O do
+        L[i]=s:sub(1,1)..tostring(tonumber(s:sub(2,2))*2)..s:sub(3,3)..tostring(tonumber(s:sub(4,4))*2)
+    end
+    return L
+end
+
 local function _reflect(a)
     return {
         [03]=_flipList(a[01]),
@@ -85,6 +112,24 @@ local function _reflect(a)
         [20]=_flipList(a[20]),
         [31]=_flipList(a[13]),
         [13]=_flipList(a[31]),
+    }
+end
+
+
+local function _big(a)
+    return {
+        [03]=_bigList(a[03]),
+        [01]=_bigList(a[01]),
+        [30]=_bigList(a[30]),
+        [32]=_bigList(a[32]),
+        [23]=_bigList(a[23]),
+        [21]=_bigList(a[21]),
+        [10]=_bigList(a[10]),
+        [12]=_bigList(a[12]),
+        [02]=_bigList(a[02]),
+        [20]=_bigList(a[20]),
+        [31]=_bigList(a[31]),
+        [13]=_bigList(a[13]),
     }
 end
 
@@ -122,7 +167,7 @@ do
             {'setCL',1,1,1},
             {'fRect',4,4,2,2},
         },
-        centerDisp=TABLE.new(true,29),
+        centerDisp=TABLE.new(true,58),
         kickTable={
             {
                 [01]={'+0+0','-1+0','-1+1','+0-2','-1+2','+0+1'},
@@ -442,6 +487,16 @@ do
     TRS.kickTable[24]=_reflect(TRS.kickTable[23])-- NH
     _centroSymSet(TRS.kickTable[8])_centroSymSet(TRS.kickTable[9])-- S5Z5
     _centroSymSet(TRS.kickTable[25])_centroSymSet(TRS.kickTable[26])-- I5I3
+
+    for i = 30, 34 do
+        TRS.kickTable[i]=_big(TRS.kickTable[i-29])
+    end
+    for i = 36, 46 do
+        TRS.kickTable[i]=_big(TRS.kickTable[i-29])
+    end
+    for i = 48, 57 do
+        TRS.kickTable[i]=_big(TRS.kickTable[i-29])
+    end
 end
 
 local SRS -- Pentos are treated as 3*3 piece
@@ -487,6 +542,10 @@ do
     }
     for i=2,5 do SRS.kickTable[i]=SRS.kickTable[1] end
     for i=8,29 do SRS.kickTable[i]=SRS.kickTable[1] end
+    for i = 30, 59 do
+        SRS.kickTable[i]=_big(SRS.kickTable[i-29])
+    end
+    
 end
 
 local SRS_plus -- Basic 180 kicks and symmetry I piece kick table
@@ -540,6 +599,9 @@ do
     }
     for i=2,5 do SRS_plus.kickTable[i]=SRS_plus.kickTable[1] end
     for i=8,29 do SRS_plus.kickTable[i]=SRS_plus.kickTable[1] end
+    for i = 30, 59 do
+        SRS_plus.kickTable[i]=_big(SRS_plus.kickTable[i-29])
+    end
 end
 
 local SRS_X -- Basic 180 kicks and TRS for non-SZJLT
@@ -580,9 +642,13 @@ do
     for i=7,29 do SRS_X.kickTable[i]=TRS.kickTable[i] end
     SRS_X.kickTable[10]=SRS_X.kickTable[1]-- P
     SRS_X.kickTable[11]=SRS_X.kickTable[1]-- Q
+    for i = 30, 57 do -- TRS does not have kicks for O1
+        SRS_X.kickTable[i]=_big(SRS_X.kickTable[i-29])
+    end
 end
 
 local BiRS
+-- TODO: Big piece behavior for BiRS
 do
     local R=_strToVec{'+0+0','-1+0','-1-1','+0-1','-1+1','+1-1','+1+0','+0+1','+1+1','+0+2','-1+2','+1+2','-2+0','+2+0'}
     local L=_strToVec{'+0+0','+1+0','+1-1','+0-1','+1+1','-1-1','-1+0','+0+1','-1+1','+0+2','+1+2','-1+2','+2+0','-2+0'}
@@ -752,6 +818,10 @@ do
     centerPos[26]={[0]={0,1},{0,0},{0,1},{0,0}}-- I3
     centerPos[28]={[0]={0,1},{0,0},{0,1},{0,0}}-- I2
 
+    for i = 30,58 do
+        centerPos[i]=_bigRotationCenter(centerPos[i-29])
+    end
+
     ARS_Z={
         centerTex=GC.DO{10,10,
             {'setLW',2},
@@ -787,6 +857,10 @@ do
     centerPos[24]={[0]={1.5,1.5},{1.5,0.5},{1.5,1.5},{1.5,0.5}}-- H
     centerPos[26]={[0]={0,1},{0,0},{0,1},{0,0}}-- I3
     centerPos[28]={[0]={0,1},{0,0},{0,1},{0,0}}-- I2
+
+    for i = 30,58 do
+        centerPos[i]=_bigRotationCenter(centerPos[i-29])
+    end
 
     local L={'+0+0','-1+0','+1+0','+0-1','-1-1','+1-1'}
     local R={'+0+0','+1+0','-1+0','+0-1','+1-1','-1-1'}
@@ -846,6 +920,10 @@ do
     centerPos[24]={[0]={0,2},{1,0},{1,1},{2,1}}-- H
     centerPos[27]={[0]={0,1},{0,0},{1,0},{1,1}}-- C
     centerPos[28]={[0]={0,1},{0,0},{0,0},{1,0}}-- I2
+
+    for i = 30,58 do
+        centerPos[i]=_bigRotationCenter(centerPos[i-29])
+    end
 
     ASC={
         centerTex=GC.DO{10,10,
@@ -992,6 +1070,10 @@ local Classic do
     centerPos[1]={[0]={1,1},{1,0},{1,1},{1,0}}
     centerPos[2]={[0]={1,1},{1,0},{1,1},{1,0}}
     centerPos[7]={[0]={0,2},{1,0},{0,2},{1,0}}
+    for i = 30,31 do
+        centerPos[i]=_bigRotationCenter(centerPos[i-29])
+    end
+    centerPos[36]=_bigRotationCenter(centerPos[7])
     Classic={
         centerTex=GC.DO{10,10,
             {'setLW',2},
@@ -1010,6 +1092,10 @@ local Classic_plus do
     centerPos[1]={[0]={1,1},{1,0},{1,1},{1,0}}
     centerPos[2]={[0]={1,1},{1,0},{1,1},{1,0}}
     centerPos[7]={[0]={0,2},{1,0},{0,2},{1,0}}
+    for i = 30,31 do
+        centerPos[i]=_bigRotationCenter(centerPos[i-29])
+    end
+    centerPos[36]=_bigRotationCenter(centerPos[7])
     Classic_plus={
         centerTex=GC.DO{10,10,
             {'setLW',2},
@@ -1061,7 +1147,7 @@ local RSlist={
 
 for name,rs in next,RSlist do
     rs.name=name
-    if not rs.centerDisp then rs.centerDisp=TABLE.new(true,29) end
+    if not rs.centerDisp then rs.centerDisp=TABLE.new(true,58) end
     if not rs.centerPos then rs.centerPos=defaultCenterPos end
     if not rs.centerTex then rs.centerTex=defaultCenterTex end
 

--- a/parts/gameTables.lua
+++ b/parts/gameTables.lua
@@ -4,6 +4,12 @@ BLOCK_NAMES={
     'Z5','S5','P','Q','F','E',
     'T5','U','V','W','X',
     'J5','L5','R','Y','N','H','I5',
+    'I3','C','I2','O1',
+    -- Might want to add the indication that those pieces are big, or change the logic altogether.
+    'Z','S','J','L','T','O','I',
+    'Z5','S5','P','Q','F','E',
+    'T5','U','V','W','X',
+    'J5','L5','R','Y','N','H','I5',
     'I3','C','I2','O1'
 }
 BLOCK_CHARS={} for i=1,#BLOCK_NAMES do BLOCK_CHARS[i]=CHAR.mino[BLOCK_NAMES[i]] end
@@ -241,6 +247,22 @@ do-- BLOCKS
         -- Dot
         {{O}},-- O1
     }
+    local function _createBigPiece(piece)
+        local bigPiece = {}
+        local rows, columns = #piece, #piece[1]
+        for row = 1, rows * 2 do
+            bigPiece[row] = {}
+            for column = 1, columns * 2 do
+                bigPiece[row][column]=piece[math.ceil(row/2)][math.ceil(column/2)]
+            end
+        end
+        return bigPiece
+    end
+
+    for i = 30, 58 do
+        BLOCKS[i]=_createBigPiece(BLOCKS[i-29])
+    end
+
     local function _RotCW(B)
         local N={}
         local r,c=#B,#B[1]-- row,col

--- a/parts/player/init.lua
+++ b/parts/player/init.lua
@@ -34,6 +34,13 @@ local function _getNewStatTable()
         T.clears[i]=0
         T.spins[i]=0
     end
+    -- Big pieces - Undecacrashes are possible, so need more entries
+    for i=30,58 do
+        T.clear[i]={0,0,0,0,0,0,0,0,0,0,0}
+        T.spin[i]={0,0,0,0,0,0,0,0,0,0,0,0}
+        T.clears[i]=0
+        T.spins[i]=0
+    end
     return T
 end
 local function _newEmptyPlayer(id,mini)

--- a/parts/player/player.lua
+++ b/parts/player/player.lua
@@ -1907,6 +1907,9 @@ do
         piece.spin,piece.mini=dospin,false
         piece.pc,piece.hpc=false,false
         piece.special=false
+        -- TODO: Replace this with a game variable
+            local bigMode = true
+            if bigMode then cc = math.floor(cc/2) end
         if cc>0 then-- If lines cleared,about 200 lines of codes below
             cmb=cmb+1
             if dospin then
@@ -2012,7 +2015,7 @@ do
             end
 
             -- PC/HPC
-            if clear and cc>=#C.bk then
+            if clear and cc>=(bigMode and #C.bk/2 or #C.bk) then
                 if CY==1 then
                     piece.pc=true
                     piece.special=true

--- a/parts/player/player.lua
+++ b/parts/player/player.lua
@@ -1441,14 +1441,14 @@ end
 
 function Player:_getBlock(id,name,color,bagLineCounter)-- Get a block object
     local ENV=self.gameEnv
-    local dir=ENV.face[id]
+    local dir=ENV.face[id%29]
     return {
         id=id,
         dir=dir,
         bk=BLOCKS[id][dir],
         RS=self.RS,
         name=name or id,
-        color=ENV.bone and 17 or color or ENV.skin[id],
+        color=ENV.bone and 17 or color or ENV.skin[id%29],
         bagLine=bagLineCounter,
     }
 end
@@ -1666,6 +1666,94 @@ do
             {1,2,2,1,0,1,2,3,2,1},
             1,1,1
         },-- O1
+        -- TODO: Finesse for big pieces, so far it's a copy of a small piece finesse
+        {
+            {1,2,1,0,1,2,2,1},
+            {2,2,2,1,1,2,3,2,2},
+            1,2
+        },-- Big Z
+        1,-- Big S
+        {
+            {1,2,1,0,1,2,2,1},
+            {2,2,3,2,1,2,3,3,2},
+            {3,4,3,2,3,4,4,3},
+            {2,3,2,1,2,3,3,2,2},
+        },-- Big J
+        3,-- Big L
+        3,-- Big T
+        {
+            {1,2,2,1,0,1,2,2,1},
+            1,1,1
+        },-- Big O
+        {
+            {1,2,1,0,1,2,1},
+            {2,2,2,2,1,1,2,2,2,2},
+            1,2
+        },-- Big I
+        {
+            {1,2,1,0,1,2,2,1},
+            {2,3,2,1,2,3,3,2},
+            1,2
+        },-- Big Z5
+        8,-- Big S5
+        3,-- Big P
+        3,-- Big Q
+        {
+            {1,2,1,0,1,2,2,1},
+            {2,3,2,1,2,3,3,2},
+            {3,4,3,2,3,4,4,3},
+            2
+        },-- Big F
+        12,-- Big E
+        12,-- Big T5
+        3,-- Big U
+        {
+            {1,2,1,0,1,2,2,1},
+            {2,3,3,2,1,2,3,2},
+            {3,4,4,3,2,3,4,3},
+            {2,3,2,1,2,3,3,2},
+        },-- Big V
+        12,-- Big W
+        {
+            {1,2,1,0,1,2,2,1},
+            1,1,1
+        },-- Big X
+        {
+            {1,2,1,0,1,2,1},
+            {2,2,3,2,1,2,3,2,2},
+            {3,4,3,2,3,4,3},
+            2,
+        },-- Big J5
+        19,-- Big L5
+        19,-- Big R
+        19,-- Big Y
+        19,-- Big N
+        19,-- Big H
+        {
+            {1,1,0,1,2,1},
+            {2,3,2,2,1,2,3,2,3,2},
+            1,2
+        },-- Big I5
+        {
+            {1,2,1,0,1,2,2,1},
+            {2,2,3,2,1,2,3,3,2,2},
+            1,2
+        },-- Big I3
+        {
+            {1,2,2,1,0,1,2,2,1},
+            {2,3,3,2,1,2,3,3,2},
+            {3,4,4,3,2,3,4,4,3},
+            2
+        },-- Big C
+        {
+            {1,2,2,1,0,1,2,2,1},
+            {2,2,3,2,1,1,2,3,2,2},
+            1,2
+        },-- Big I2
+        {
+            {1,2,2,1,0,1,2,3,2,1},
+            1,1,1
+        },-- Big O1
     }
     for k,v in next,finesseList do
         if type(v)=='table' then
@@ -2144,11 +2232,11 @@ do
         end
         local n=C.name
         if dospin then
-            _=Stat.spin[n]  _[cc+1]=_[cc+1]+1-- Spin[1~25][0~4]
-            _=Stat.spins    _[cc+1]=_[cc+1]+1-- Spin[0~4]
+            _=Stat.spin[n]  _[cc+1]=_[cc+1]+1 or 1-- Spin[1~25][0~4]
+            _=Stat.spins    _[cc+1]=_[cc+1]+1 or 1-- Spin[0~4]
         elseif cc>0 then
-            _=Stat.clear[n] _[cc]=_[cc]+1-- Clear[1~25][1~5]
-            _=Stat.clears   _[cc]=_[cc]+1-- Clear[1~5]
+            _=Stat.clear[n] _[cc]=_[cc]+1 or 1-- Clear[1~25][1~5]
+            _=Stat.clears   _[cc]=_[cc]+1 or 1-- Clear[1~5]
         end
 
         if finish then

--- a/parts/scenes/custom_sequence.lua
+++ b/parts/scenes/custom_sequence.lua
@@ -105,11 +105,11 @@ function scene.keyDown(key)
         cur=cur+1
         ins(BAG,cur,key)
     elseif #key==1 then
-        key=(kb.isDown('lshift','lalt','rshift','ralt') and minoKey2 or minoKey)[key]
+        key=(kb.isDown('lalt','ralt') and minoKey2 or minoKey)[key]
         if key then
             local p=cur+1
             while BAG[p]==key do p=p+1 end
-            ins(BAG,p,key)
+            ins(BAG,p,kb.isDown('lshift','rshift') and key+29 or key)
             cur=p
             SFX.play('lock')
         end
@@ -151,7 +151,7 @@ function scene.draw()
             end
             if i<=j then
                 setFont(60)
-                gc_setColor(BLOCK_COLORS[skinSetting[BAG[i]]])
+                gc_setColor(BLOCK_COLORS[skinSetting[((BAG[i]-1)%29)+1]])
                 gc_print(BLOCK_CHARS[BAG[i]],x,y-40)
                 x=x+blockCharWidth[BAG[i]]
             end


### PR DESCRIPTION
This PR adds giant pieces to the game to hopefully replace the Big mode with actual giant pieces.

Tasks:
[v] Added mono-pentomino giant pieces
[v] A function to deduce rotation centers of giant pieces
[v] A function to deduce kick tables of giant pieces for kick tables that use vector strings
[v] Halved line clear logic with correct PC detection
[ ] 3-corner spin detection check for giant tetrominoes
[ ] 2-cell giant piece movement mode
[ ] Giant piece spawnpoints aligned to 5x10 grid when Big Mode is enabled
[ ] Big Mode setting, changing the big piece behavior