### PR TITLE
fix macos portable ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -358,6 +358,7 @@ jobs:
           bundle-id: ${{ steps.process-app-name.outputs.bundle-id }}
           copyright: "Copyright © 2019-2023 26F-Studio. Some Rights Reserved."
           icon-path: ./.github/build/macOS/${{ env.BUILD_TYPE }}/icon.icns
+          love-ref: "11.5"
           love-package: ${{ env.CORE_LOVE_PACKAGE_PATH }}
           libs-path: ./ColdClear/universal/
           product-name: ${{ steps.process-app-name.outputs.product-name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -350,6 +350,12 @@ jobs:
         shell: bash
         run: |
           rm ./ColdClear/universal/libcold_clear.a
+      - name: Use Xcode 15.3
+        # Xcode 15.4 segfaults
+        # see https://forums.developer.apple.com/forums/thread/757398
+        uses: mobiledevops/xcode-select-version-action@v1
+        with:
+          xcode-select-version: 15.3
       - name: Build macOS packages
         id: build-packages
         uses: love-actions/love-actions-macos-portable@v1


### PR DESCRIPTION
The true change is the Xcode 15.3. Xcode 15.4 for some reason just segfaults in our ci, and a similar problem is posted [here](https://forums.developer.apple.com/forums/thread/757398). I will submit issues in techmino and love2d to track this bug.
Love is also updated to 11.5, but this should not matter.