### PR TITLE
Fix a wierd bug

### DIFF
--- a/parts/scenes/customGame.lua
+++ b/parts/scenes/customGame.lua
@@ -145,6 +145,7 @@ local function _play(mode)
         end
     end
     saveFile(CUSTOMGAME_LOCAL.customenv,'conf/customEnv')
+    apply_locals()
     loadGame('custom_'..mode,true)
 end
 


### PR DESCRIPTION
# Steps to reproduce
1. reset everything in custom game
2. restart the game
3. go to the custom game scene
4. go to the custom sequence scene and set a new sequence
5. leave the scene and go to the custom game scene
6. begin to clear

# Unintended behavior
The sequence is still the default old sequence (7-bag)

# Intended behavior
The sequence is the newly set sequence

# Rationale
The bug was introduced by #1139.
It deleted a line of `apply_locals()` which I wrongly believed that the custom modes will execute initialize() anyway, but it turned out initialization is only executed during the start of the whole game. The patch is simple: just add back the deleted line